### PR TITLE
Add fetch function for WAC-allow tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 
 import * as rdf from 'rdflib'
 import { NamedNode, Statement, IndexedFomula } from 'rdflib'
-import solidNamespace from 'solid-namespace'
+import * as solidNamespace from 'solid-namespace'
 
 import * as debug from './debug'
 
@@ -21,6 +21,7 @@ export class SolidLogic {
 
   store: IndexedFomula
   me: string | undefined
+  fetcher: { fetch: (url: string, options?: any) => any }
   constructor (fetcher: { fetch: () => any }, me?: string) {
     this.store = rdf.graph() // Make a Quad store
     rdf.fetcher(this.store, fetcher) // Attach a web I/O module, store.fetcher
@@ -29,7 +30,8 @@ export class SolidLogic {
       profileDocument: {},
       preferencesFile: {}
     }
-    this.me = me;
+    this.me = me
+    this.fetcher = fetcher
   }
 
   async findAclDocUrl (url: string | NamedNode) {
@@ -232,6 +234,10 @@ export class SolidLogic {
 
   clearStore () {
     this.store.statements.slice().forEach(this.store.remove.bind(this.store))
+  }
+
+  async fetch (url: string, options?: any) {
+    return this.fetcher.fetch(url, options)
   }
 }
 


### PR DESCRIPTION
I wasn't sure about calling this.store.fetcher._fetch as that gives the impression of a private function so I stored the fetcher in the instance. Feel free to change this if you prefer.
I needed to change the namespace import as I was getting an error in the tests.
Lastly, I noticed that recursiveDelete swallows exceptions - as I am not aware of the exception strategy would you mind changing this so it either wraps and re-throws it or doesn't catch it here.